### PR TITLE
Add auth module

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,21 @@
     "email": "hawkinswritescode@gmail.com",
     "url": "https://github.com/hawkins"
   },
-  "contributors": [{
-    "name": "J. Dalton Childers",
-    "email": "dalton@jdaltonchilders.org",
-    "url": "https://www.github.com/jdaltonchilders"
-  }],
+  "contributors": [
+    {
+      "name": "J. Dalton Childers",
+      "email": "dalton@jdaltonchilders.org",
+      "url": "https://www.github.com/jdaltonchilders"
+    }
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/hawkins/git-web/issues"
   },
   "homepage": "https://github.com/hawkins/git-web#readme",
   "dependencies": {
-    "github": "^9.2.0"
+    "github": "^9.2.0",
+    "homedir": "^0.6.0"
   },
   "devDependencies": {
     "jest": "^19.0.2"

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,57 @@
+const fs = require("fs");
+const homedir = require("homedir");
+
+const configFilePath = `${homedir()}/.git-web.json`;
+
+const getConfig = () => {
+  // Load file and return parse, fallback to empty object
+  var fileContents = "{}";
+  try {
+    fileContents = fs.readFileSync(configFilePath);
+  } catch (err) {}
+  return JSON.parse(fileContents);
+};
+
+const setConfig = properties => {
+  // Load the config
+  var config = getConfig();
+
+  // Save new properties
+  const props = Object.keys(properties);
+  props.forEach(property => {
+    config[property] = properties[property];
+  });
+
+  // Write new config object to file
+  fileContents = JSON.stringify(config);
+  fs.writeFileSync(configFilePath, fileContents);
+};
+
+const createAuthToken = github => {
+  github.authorization.create(
+    {
+      scopes: ["user", "public_repo", "repo", "repo:status", "gist"],
+      note: "git-web",
+      note_url: "https://github.com/hawkins/git-web",
+      headers: {
+        "X-GitHub-OTP": "two-factor-code"
+      }
+    },
+    (err, res) => {
+      if (err) {
+        // Probably already have a token
+        console.error("Unable to create authentication token.");
+      } else {
+        setConfig({ auth: res.data.token });
+        console.log("Saved authentication token");
+      }
+    }
+  );
+};
+
+const login = (github, username) => {
+  setConfig({ username });
+  createAuthToken(github);
+};
+
+module.exports = { login, getConfig, setConfig, createAuthToken };

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,27 @@
 const GitHubApi = require("github");
 
 const issues = require("./commands/issues");
+const auth = require("./auth");
 
 const username = process.argv[2];
 const password = process.argv[3];
 
 var github = new GitHubApi({
-    // optional
-    // debug: true,
-    protocol: "https",
-    host: "api.github.com",
-    headers: {
-        "user-agent": "Git-Web" // GitHub is happy with a unique user agent
-    },
-    followRedirects: false, // default: true; there's currently an issue with non-get redirects, so allow ability to disable follow-redirects
-    timeout: 5000
+  // optional
+  // debug: true,
+  protocol: "https",
+  host: "api.github.com",
+  headers: {
+    "user-agent": "Git-Web" // GitHub is happy with a unique user agent
+  },
+  followRedirects: false, // default: true; there's currently an issue with non-get redirects, so allow ability to disable follow-redirects
+  timeout: 5000
 });
 
 github.authenticate({
-    type: "basic",
-    username: username,
-    password: password
+  type: "basic",
+  username: username,
+  password: password
 });
 
 // Decide command
@@ -29,4 +30,6 @@ const command = process.argv[4].toLowerCase();
 // Execute command
 if (command === "issue" || command === "issues") {
   issues(process.argv.slice(5), github);
+} else if (command === "login") {
+  auth.login(github, username);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -747,6 +747,10 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+homedir@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/homedir/-/homedir-0.6.0.tgz#2b21db66bf08a6db38249a3eff52d7d18706af1e"
+
 hosted-git-info@^2.1.4:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.1.tgz#4b0445e41c004a8bd1337773a4ff790ca40318c8"


### PR DESCRIPTION
With `setConfig` similar to `react#setState`

`getConfig` that returns the config object or `{}` if does not exist

`createAuthToken` that creates an authentication token for git-web on the user's GitHub account

`login` that creates an authentication token and stores username

#### Still to-do

- [ ] Rewrite `auth#login` to provide an interactive prompt for providing email, password to GitHub.
  - Similar to [Zeit's Now login](https://github.com/zeit/now-cli/blob/master/lib/login.js), perhaps?
- [ ] Have commands like issues.js use auth module
